### PR TITLE
fixed estimator import, added gitignore for compilation files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.egg-info/

--- a/src/relplot/estimators.py
+++ b/src/relplot/estimators.py
@@ -6,7 +6,7 @@
 import numpy as np
 import sklearn
 from sklearn.base import BaseEstimator
-from sklearn.utils._estimator_html_repr import _VisualBlock
+from sklearn.utils._repr_html.estimator import _VisualBlock
 
 
 class KernelSmoother(BaseEstimator):


### PR DESCRIPTION
`sklearn.utils._estimator_html_repr` seems to have been phased out and replaced with `sklearn.utils._repr_html.estimator` ([source](https://github.com/scikit-learn/scikit-learn/blob/da08f3d99194565caaa2b6757a3816eef258cd70/sklearn/utils/_repr_html/estimator.py)). Worth double checking on your end, but fixing the import fixes relplot plotting for me (which was otherwise broken).