### PR TITLE
Speed up

### DIFF
--- a/src/relplot/kernels.py
+++ b/src/relplot/kernels.py
@@ -108,7 +108,7 @@ class GaussianKernel(BaseKernelMixin):
 
     def convolve(self, values, eval_points):
         ker = self.kernel_ev(eval_points)
-        return np.convolve(values, ker, 'same')
+        return sp.signal.convolve(values, ker, 'same')
 
     def apply(self, f, y, x_eval, eval_points = None):
         if eval_points is None:
@@ -128,7 +128,7 @@ class ReflectedGaussianKernel(GaussianKernel):
     def convolve(self, values, eval_points):
         ker = self.kernel_ev(eval_points)
         ext_vals = np.concatenate([np.flip(values)[:-1], values, np.flip(values)[1:]])
-        return np.convolve(ext_vals, ker, "valid")[eval_points//2 : eval_points//2 + eval_points]
+        return sp.signal.convolve(ext_vals, ker, "valid")[eval_points//2 : eval_points//2 + eval_points]
 
 class TruncatedGaussianKernel(BaseKernelMixin):
     def __init__(self, sigma):
@@ -143,7 +143,7 @@ class TruncatedGaussianKernel(BaseKernelMixin):
 
     def convolve(self, values, eval_points):
         ker = self.kernel_ev(eval_points)
-        return np.convolve(values, ker, 'same')
+        return sp.signal.convolve(values, ker, 'same')
 
     def apply(self, f, y, x_eval, eval_points = None):
         if eval_points is None:


### PR DESCRIPTION
Thanks you for developing this tool! 

When I was using it on my data, I found multiple times that the process get stuck when calling `smECE(pred,y)`. In the end, I realized that it was due to the inefficient implementation of `np.convolve`. I suggest that `sp.signal.convolve` be used, as it uses FFT to speed up calculation. This difference has also been pointed out in https://stackoverflow.com/questions/53550764/python-numpy-is-there-a-faster-way-to-convolve.


I have attached an example I came across on real data: [debug_y_33.5.modify_affix_to_npy.txt](https://github.com/user-attachments/files/22058540/debug_y_33.5.modify_affix_to_npy.txt) 
[debug_pred_33.5.modify_affix_to_npy.txt](https://github.com/user-attachments/files/22058541/debug_pred_33.5.modify_affix_to_npy.txt) (Github doesn't allow `.npy` files to be uploaded, so please change the affix back to `.npy`)

The results are:
- `sp.signal.convolve`: Time = 0.065s, smECE = 0.006961
- `np.convolve`: 
    - smECE = 0.006961 as well.
    - It seems that the time spent is not stable. It may vary from one to tens of seconds. But even in the best case, it's still way more time-consuming then the `sp.signal` implementation.